### PR TITLE
Update font size directly as a work around

### DIFF
--- a/GYREdgeJustifiedLabel/EdgeJustifiedLabel.swift
+++ b/GYREdgeJustifiedLabel/EdgeJustifiedLabel.swift
@@ -150,7 +150,7 @@ import UIKit
         var adjustsFontSize = adjustsFontSizeToFitWidth && minimumScaleFactor > 0
         
         while adjustsFontSize && rect.width < leftSize.width + rightSize.width + minimumSpacing {
-            workingFont = UIFont(name: workingFont.fontName, size: workingFont.pointSize - 0.5)!
+            workingFont = workingFont.withSize(workingFont.pointSize - 0.5)
             
             leftSize = nonNilLeftText.naturalRect(workingFont).size
             rightSize = nonNilRightText.naturalRect(workingFont).size


### PR DESCRIPTION
Workaround an issue in iOS13 where UIFont(name:size) was returning the incorrect font.
Radar regarding this issue: https://openradar.appspot.com/6153065